### PR TITLE
DAT-16149 DevOps :: Extensions Release Failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.3
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
       with:
         nightly: true
       secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.5
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
     secrets: inherit
 
   integration-test:

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,13 @@
         </dependency>
     </dependencies>
 
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+		<url>https://github.com/liquibase/liquibase-teradata.git</url>
+		<tag>HEAD</tag>
+	</scm>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
…ion to v0.5.5

chore(build-nightly.yml): update liquibase/build-logic version to v0.5.5
chore(codeql.yml): update liquibase/build-logic version to v0.5.5
chore(create-release.yml): update liquibase/build-logic version to v0.5.5
chore(release-published.yml): update liquibase/build-logic version to v0.5.5
chore(test.yml): update liquibase/build-logic version to v0.5.5
chore(pom.xml): add scm configuration for git repository connection and url